### PR TITLE
Fix wrong RDFS namespace in file handler

### DIFF
--- a/tests/sparql/scripts/testing/file_handler.py
+++ b/tests/sparql/scripts/testing/file_handler.py
@@ -31,7 +31,7 @@ from .types import (
 # RDF IRIs
 IRIS = {
     "RDF": rdflib.URIRef("http://www.w3.org/1999/02/22-rdf-syntax-ns#"),
-    "RDFS": rdflib.URIRef("ttp://www.w3.org/2000/01/rdf-schema#"),
+    "RDFS": rdflib.URIRef("http://www.w3.org/2000/01/rdf-schema#"),
     "MF": rdflib.URIRef("http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#"),
     "QT": rdflib.URIRef("http://www.w3.org/2001/sw/DataAccess/tests/test-query#"),
 }


### PR DESCRIPTION
## Summary
- correct the RDFS IRI in `file_handler.py`

## Testing
- `python3 -m py_compile tests/sparql/scripts/testing/file_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_683f67b452dc8321bd3e39030978ad48