### PR TITLE
Enable GET GQL queries

### DIFF
--- a/src/network/server/session/http/gql_request_parser.h
+++ b/src/network/server/session/http/gql_request_parser.h
@@ -4,6 +4,7 @@
 
 #include "network/server/protocol.h"
 #include "network/sparql/response_type.h"
+#include "network/sparql/url_helper.h"
 #include "query/executor/query_executor/gql/return_executor.h"
 
 namespace GQL { namespace RequestParser {
@@ -26,22 +27,65 @@ inline std::pair<std::string, ReturnType>
     parse_query(boost::beast::http::request<boost::beast::http::string_body>& req)
 {
     ReturnType response_type = ReturnType::CSV;
-
+    std::string content_type;
     for (auto& header : req) {
-        std::string accept_value = header.value();
-        if (header.name_string() == "Accept") {
+        std::string header_name = header.name_string();
+        if (header_name == "Accept") {
+            std::string accept_value = header.value();
             if (accept_value.find("text/tab-separated-values") != std::string::npos) {
                 response_type = ReturnType::TSV;
             }
+        } else if (header_name == "Content-Type") {
+            content_type = header.value();
         }
-        // else CSV by default
     }
 
-    // We assume that the post body contains the query, otherwise ignore contents
-    if (req.method() != boost::beast::http::verb::post) {
-        return std::make_pair("", response_type);
+    std::string url_encoded;
+    if (req.method() == boost::beast::http::verb::post) {
+        if (content_type == "application/x-www-form-urlencoded") {
+            url_encoded = req.body();
+        }
+    } else if (req.method() == boost::beast::http::verb::get) {
+        url_encoded = req.target();
     }
 
-    return std::make_pair(req.body(), response_type);
+    std::string query;
+    if (!url_encoded.empty()) {
+        const char* ptr = url_encoded.c_str();
+        if (*ptr == '/') {
+            while (*ptr != '?' && *ptr != '\0') {
+                ptr++;
+            }
+            if (*ptr != '\0')
+                ptr++;
+        }
+        while (*ptr != '\0') {
+            auto beg_key = ptr;
+            size_t len_key = 0;
+            while (*ptr != '\0' && *ptr != '=') {
+                ptr++;
+                len_key++;
+            }
+            if (*ptr != '\0')
+                ptr++;
+            auto beg_value = ptr;
+            size_t len_value = 0;
+            while (*ptr != '\0' && *ptr != '&') {
+                ptr++;
+                len_value++;
+            }
+            std::string key(beg_key, len_key);
+            std::string val(beg_value, len_value);
+            if (*ptr != '\0')
+                ptr++;
+            if (key == "query") {
+                query = UrlHelper::decode(val);
+            }
+        }
+    } else {
+        query = req.body();
+    }
+
+    return std::make_pair(query, response_type);
 }
 }} // namespace GQL::RequestParser


### PR DESCRIPTION
## Summary
- support query parameters when sending GQL requests over HTTP
- detect content type to parse urlencoded POST bodies

## Testing
- `cmake --build build/Release -j 8`
- `bash scripts/run-tests unit` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_683f8acc94cc8321b96b842639a1e670