### PR TITLE
Handle empty HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ build/Release/bin/mdb-server data/example-rdf-database
 
 Execute a Query
 --------------------------------------------------------------------------------
-Go to http://localhost:4321/
+Go to http://localhost:4321/ to use the built-in web interface.
+The HTTP endpoint on port 1234 only accepts queries sent via `POST`.
+Opening `http://localhost:1234/` directly will return a **400 Bad Request** message.
 
 Remove the Database
 --------------------------------------------------------------------------------

--- a/src/network/server/session/http/http_gql_session.cc
+++ b/src/network/server/session/http/http_gql_session.cc
@@ -77,6 +77,13 @@ void HttpGQLSession::run(std::unique_ptr<HttpGQLSession> obj)
 
     auto&& [query, response_type] = GQL::RequestParser::parse_query(obj->request);
 
+    if (query.empty()) {
+        response_ostream << "HTTP/1.1 400 Bad Request\r\n"
+                            "Content-Type: text/plain\r\n\r\n"
+                         << "Empty query. Use HTTP POST to send a GQL query.";
+        return;
+    }
+
     if (!obj->server.authorize(request_type, auth_token)) {
         response_ostream << "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\n\r\n";
         return;

--- a/src/network/server/session/http/http_quad_session.cc
+++ b/src/network/server/session/http/http_quad_session.cc
@@ -82,6 +82,13 @@ void HttpQuadSession::run(std::unique_ptr<HttpQuadSession> obj) {
 
     auto&& [query, response_type] = MQL::RequestParser::parse_query(obj->request);
 
+    if (query.empty()) {
+        response_ostream << "HTTP/1.1 400 Bad Request\r\n"
+                            "Content-Type: text/plain\r\n\r\n"
+                         << "Empty query. Use HTTP POST to send a query.";
+        return;
+    }
+
     if (!obj->server.authorize(request_type, auth_token)) {
         response_ostream << "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\n\r\n";
         return;

--- a/src/network/server/session/http/http_rdf_session.cc
+++ b/src/network/server/session/http/http_rdf_session.cc
@@ -85,6 +85,13 @@ void HttpRdfSession::run(std::unique_ptr<HttpRdfSession> obj) {
 
     auto&& [query, response_type] = SPARQL::RequestParser::parse_query(obj->request);
 
+    if (query.empty()) {
+        response_ostream << "HTTP/1.1 400 Bad Request\r\n"
+                            "Content-Type: text/plain\r\n\r\n"
+                         << "Empty query. Use HTTP POST to send a SPARQL query.";
+        return;
+    }
+
     if (!obj->server.authorize(request_type, auth_token)) {
         response_ostream << "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\n\r\n";
         return;


### PR DESCRIPTION
## Summary
- avoid parsing empty GQL/SPARQL/MQL requests
- document POST requirement for query endpoint

## Testing
- `./scripts/run-tests all` *(fails: boost headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f8914ae1083218c01e07b17e61594