### PR TITLE
Support GET requests for GQL queries

### DIFF
--- a/src/network/server/session/http/gql_request_parser.h
+++ b/src/network/server/session/http/gql_request_parser.h
@@ -37,7 +37,36 @@ inline std::pair<std::string, ReturnType>
         // else CSV by default
     }
 
-    // We assume that the post body contains the query, otherwise ignore contents
+    // If the query was sent using GET, parse it from the URL
+    if (req.method() == boost::beast::http::verb::get) {
+        std::string target = std::string(req.target());
+        auto qpos = target.find('?');
+        if (qpos != std::string::npos && qpos + 1 < target.size()) {
+            std::string query_part = target.substr(qpos + 1);
+            if (query_part.rfind("query=", 0) == 0) {
+                query_part = query_part.substr(6);
+            } else if (query_part.rfind("q=", 0) == 0) {
+                query_part = query_part.substr(2);
+            }
+            // Decode percent-encoding
+            std::string decoded;
+            for (size_t i = 0; i < query_part.size(); ++i) {
+                if (query_part[i] == '%' && i + 2 < query_part.size()) {
+                    std::string hex = query_part.substr(i + 1, 2);
+                    decoded.push_back(static_cast<char>(std::stoi(hex, nullptr, 16)));
+                    i += 2;
+                } else if (query_part[i] == '+') {
+                    decoded.push_back(' ');
+                } else {
+                    decoded.push_back(query_part[i]);
+                }
+            }
+            return std::make_pair(decoded, response_type);
+        }
+        return std::make_pair("", response_type);
+    }
+
+    // Otherwise we assume that the POST body contains the query
     if (req.method() != boost::beast::http::verb::post) {
         return std::make_pair("", response_type);
     }


### PR DESCRIPTION
## Summary
- allow HTTP GET requests to provide GQL queries via the URL

## Testing
- `scripts/run-tests unit` *(fails: installing python deps)*

------
https://chatgpt.com/codex/tasks/task_e_683f89105b408321b525b238293d8bd1