### PR TITLE
Fix IN/NOT IN node filtering

### DIFF
--- a/src/query/executor/binding_iter/binding_expr/mql/binding_expr_in.h
+++ b/src/query/executor/binding_iter/binding_expr/mql/binding_expr_in.h
@@ -18,24 +18,25 @@ public:
 
     ObjectId eval(const Binding& binding) override
     {
-        auto lhs_oid = lhs->eval(binding);
-        auto lhs_type = lhs_oid.id & ObjectId::TYPE_MASK;
+        auto lhs_oid     = lhs->eval(binding);
+        auto lhs_generic = lhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
+        auto lhs_type    = lhs_oid.id & ObjectId::TYPE_MASK;
 
-        // skip bindings that are not real nodes
-        if (lhs_type != ObjectId::MASK_NODE)
+        // ignore relations and internal edge identifiers (_eX)
+        if (lhs_generic == ObjectId::MASK_EDGE || lhs_type == ObjectId::MASK_EDGE_LABEL)
             return ObjectId::get_null();
 
         bool compatible = false;
         for (auto& expr : rhs) {
-            auto rhs_oid = expr->eval(binding);
-            auto rhs_type = rhs_oid.id & ObjectId::TYPE_MASK;
+            auto rhs_oid     = expr->eval(binding);
+            auto rhs_generic = rhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
+            auto rhs_type    = rhs_oid.id & ObjectId::TYPE_MASK;
 
-            if (rhs_type != ObjectId::MASK_NODE)
-                continue;
-
-            compatible = true;
-            if (lhs_oid == rhs_oid) {
-                return ObjectId(ObjectId::BOOL_TRUE);
+            if (rhs_generic == lhs_generic && rhs_type == lhs_type) {
+                compatible = true;
+                if (lhs_oid == rhs_oid) {
+                    return ObjectId(ObjectId::BOOL_TRUE);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- restore previous logic in MQL `BindingExprIn` to allow real nodes to be used
- continue ignoring edges and `_eX` identifiers when evaluating `IN` and `NOT IN`

## Testing
- `./scripts/run-tests mql` *(fails: fatal error: boost/uuid/random_generator.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687963d110a48331a8b91bc7e6ba8ca2