### PR TITLE
Fix NOT IN filter on relations

### DIFF
--- a/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
+++ b/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
@@ -11,37 +11,33 @@ public:
     std::unique_ptr<BindingExpr> lhs;
     std::vector<std::unique_ptr<BindingExpr>> rhs;
 
-    BindingExprNotIn(std::unique_ptr<BindingExpr> lhs,
-                     std::vector<std::unique_ptr<BindingExpr>> rhs) :
+    BindingExprNotIn(std::unique_ptr<BindingExpr> lhs, std::vector<std::unique_ptr<BindingExpr>> rhs) :
         lhs(std::move(lhs)),
         rhs(std::move(rhs))
     { }
 
     ObjectId eval(const Binding& binding) override
     {
-        auto lhs_oid  = lhs->eval(binding);
+        auto lhs_oid = lhs->eval(binding);
+        auto lhs_generic = lhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
         auto lhs_type = lhs_oid.id & ObjectId::TYPE_MASK;
 
-        // skip bindings that are not real nodes
-        if (lhs_type != ObjectId::MASK_NODE)
-            return ObjectId::get_null();
-        bool compatible = false;
+        // ignore relations and internal edge identifiers (_eX)
+        if (lhs_generic == ObjectId::MASK_EDGE || lhs_type == ObjectId::MASK_EDGE_LABEL)
+            return ObjectId(ObjectId::BOOL_TRUE);
+
         for (auto& expr : rhs) {
-            auto rhs_oid  = expr->eval(binding);
+            auto rhs_oid = expr->eval(binding);
+            auto rhs_generic = rhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
             auto rhs_type = rhs_oid.id & ObjectId::TYPE_MASK;
 
-            if (rhs_type != ObjectId::MASK_NODE)
-                continue;
-
-            compatible = true;
-            if (lhs_oid == rhs_oid) {
-                return ObjectId(ObjectId::BOOL_FALSE);
+            if (rhs_generic == lhs_generic && rhs_type == lhs_type) {
+                if (lhs_oid == rhs_oid) {
+                    return ObjectId(ObjectId::BOOL_FALSE);
+                }
             }
         }
 
-        if (!compatible) {
-            return ObjectId::get_null();
-        }
         return ObjectId(ObjectId::BOOL_TRUE);
     }
 


### PR DESCRIPTION
## Summary
- adjust `BindingExprNotIn` so edges are ignored
- return TRUE for relations and exclude only listed nodes

## Testing
- `scripts/run-tests unit` *(fails: missing Boost headers)*

------
https://chatgpt.com/codex/tasks/task_e_687fe212fba08331bbc0f6a9f94b8984