### PR TITLE
Add optional semantics for CALL statements

### DIFF
--- a/src/query/executor/binding_iter/gql/call_binding_iter.h
+++ b/src/query/executor/binding_iter/gql/call_binding_iter.h
@@ -27,6 +27,8 @@ protected:
     uint64_t result_count = 0;
     bool exhausted = false;
     Binding* parent_binding = nullptr;
+    bool is_optional = false;
+    bool returned_null_row = false;
 };
 
 class CallNamedBindingIter : public CallBindingIter {
@@ -35,7 +37,8 @@ public:
         const std::string& procedure_name,
         const std::vector<std::unique_ptr<Expr>>& arguments,
         const std::vector<VarId>& yield_vars,
-        const std::vector<std::string>& yield_fields
+        const std::vector<std::string>& yield_fields,
+        bool is_optional = false
     );
 
     void print(std::ostream& os, int indent, bool stats) const override;
@@ -52,6 +55,7 @@ private:
     std::vector<std::string> yield_fields;
     std::vector<std::unordered_map<std::string, std::string>> procedure_results;
     size_t current_result_index = 0;
+    bool executed = false;
 
     void execute_db_labels();
     void execute_db_property_keys();
@@ -62,7 +66,8 @@ class CallInlineBindingIter : public CallBindingIter {
 public:
     CallInlineBindingIter(
         std::unique_ptr<BindingIter> subquery_iter,
-        const std::vector<VarId>& yield_vars
+        const std::vector<VarId>& yield_vars,
+        bool is_optional = false
     );
 
     void print(std::ostream& os, int indent, bool stats) const override;

--- a/src/query/optimizer/property_graph_model/binding_list_iter_constructor.cc
+++ b/src/query/optimizer/property_graph_model/binding_list_iter_constructor.cc
@@ -533,7 +533,8 @@ void PathBindingIterConstructor::visit(OpCallNamed& op_call_named)
         op_call_named.get_procedure_name(),
         std::move(arguments),
         std::move(yield_vars),
-        std::move(yield_fields)
+        std::move(yield_fields),
+        op_call_named.get_is_optional()
     );
 }
 
@@ -552,6 +553,7 @@ void PathBindingIterConstructor::visit(OpCallInline& op_call_inline)
     // Create the CallInlineBindingIter
     tmp_iter = std::make_unique<CallInlineBindingIter>(
         std::move(subquery_constructor.tmp_iter),
-        std::move(yield_vars)
+        std::move(yield_vars),
+        op_call_inline.get_is_optional()
     );
 }


### PR DESCRIPTION
## Summary
- propagate `is_optional` flag when constructing call iterators
- allow `CallNamedBindingIter` and `CallInlineBindingIter` to emit a null row when optional
- rename `procedure_executed` flag to `executed`

## Testing
- `cmake --build build/Release -j5`
- `cd build/Release && ctest --output-on-failure -j5`


------
https://chatgpt.com/codex/tasks/task_e_68828c5e2cb48321b09fc05f2491b3cc