### PR TITLE
Refactor GQL named procedure calls

### DIFF
--- a/src/query/executor/binding_iter/gql/call_binding_iter.h
+++ b/src/query/executor/binding_iter/gql/call_binding_iter.h
@@ -53,13 +53,11 @@ private:
     std::string procedure_name;
     std::vector<std::unique_ptr<Expr>> arguments;
     std::vector<std::string> yield_fields;
-    std::vector<std::unordered_map<std::string, std::string>> procedure_results;
+    using ResultRow = std::unordered_map<std::string, ObjectId>;
+    std::vector<ResultRow> procedure_results;
     size_t current_result_index = 0;
     bool executed = false;
 
-    void execute_db_labels();
-    void execute_db_property_keys();
-    void execute_db_relationship_types();
 };
 
 class CallInlineBindingIter : public CallBindingIter {


### PR DESCRIPTION
## Summary
- call GQL named procedures via a simple registry
- fetch real values from the catalog for `db.labels`, `db.propertyKeys` and `db.relationshipTypes`
- validate requested yield fields

## Testing
- `cmake -B build/Release -D CMAKE_BUILD_TYPE=Release`
- `cmake --build build/Release/ -j 5`
- `build/Release/bin/mdb help | head -n 5`
- `build/Release/bin/mdb import data/example/gql/posts/posts.gql data/dbs/gql/posts`
- `build/Release/bin/mdb server data/dbs/gql/posts` *(terminated immediately)*
- `ctest --output-on-failure -j 5`

------
https://chatgpt.com/codex/tasks/task_e_68829b532cb48321ba3f8d4d8fd8d712