### PR TITLE
Fix NOT IN clause type filtering

### DIFF
--- a/src/query/executor/binding_iter/binding_expr/mql/binding_expr_in.h
+++ b/src/query/executor/binding_iter/binding_expr/mql/binding_expr_in.h
@@ -18,19 +18,23 @@ public:
 
     ObjectId eval(const Binding& binding) override
     {
-        auto lhs_oid     = lhs->eval(binding);
+        auto lhs_oid = lhs->eval(binding);
         auto lhs_generic = lhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
-        auto lhs_type    = lhs_oid.id & ObjectId::TYPE_MASK;
+        auto lhs_type = lhs_oid.id & ObjectId::TYPE_MASK;
 
-        // ignore relations and internal edge identifiers (_eX)
-        if (lhs_generic == ObjectId::MASK_EDGE || lhs_type == ObjectId::MASK_EDGE_LABEL)
+        // ignore relations, labels and internal edge identifiers (_eX)
+        if (lhs_type == ObjectId::MASK_DIRECTED_EDGE || lhs_type == ObjectId::MASK_UNDIRECTED_EDGE
+            || lhs_type == ObjectId::MASK_EDGE_LABEL || lhs_type == ObjectId::MASK_NODE_LABEL
+            || lhs_type == ObjectId::MASK_EDGE_KEY || lhs_type == ObjectId::MASK_NODE_KEY)
+        {
             return ObjectId::get_null();
+        }
 
         bool compatible = false;
         for (auto& expr : rhs) {
-            auto rhs_oid     = expr->eval(binding);
+            auto rhs_oid = expr->eval(binding);
             auto rhs_generic = rhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
-            auto rhs_type    = rhs_oid.id & ObjectId::TYPE_MASK;
+            auto rhs_type = rhs_oid.id & ObjectId::TYPE_MASK;
 
             if (rhs_generic == lhs_generic && rhs_type == lhs_type) {
                 compatible = true;

--- a/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
+++ b/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
@@ -23,9 +23,9 @@ public:
         auto lhs_type = lhs_oid.id & ObjectId::TYPE_MASK;
 
         // ignore relations, labels and internal edge identifiers (_eX)
-        if (lhs_generic == ObjectId::MASK_EDGE || lhs_type == ObjectId::MASK_EDGE_LABEL
-            || lhs_type == ObjectId::MASK_NODE_LABEL || lhs_type == ObjectId::MASK_EDGE_KEY
-            || lhs_type == ObjectId::MASK_NODE_KEY)
+        if (lhs_type == ObjectId::MASK_DIRECTED_EDGE || lhs_type == ObjectId::MASK_UNDIRECTED_EDGE
+            || lhs_type == ObjectId::MASK_EDGE_LABEL || lhs_type == ObjectId::MASK_NODE_LABEL
+            || lhs_type == ObjectId::MASK_EDGE_KEY || lhs_type == ObjectId::MASK_NODE_KEY)
         {
             return ObjectId::get_null();
         }


### PR DESCRIPTION
## Summary
- ensure `NOT IN` only compares entities of matching type and ignores edges

## Testing
- `cmake --build build --target mdb-server mdb-import -j 8` *(build interrupted at ~35%)*

------
https://chatgpt.com/codex/tasks/task_e_688e2a13a59083319cd7337170845d7d