### PR TITLE
Fix NOT IN evaluation for MQL bindings

### DIFF
--- a/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
+++ b/src/query/executor/binding_iter/binding_expr/mql/binding_expr_not_in.h
@@ -19,6 +19,11 @@ public:
     ObjectId eval(const Binding& binding) override
     {
         auto lhs_oid = lhs->eval(binding);
+
+        if (lhs_oid.is_null()) {
+            return ObjectId::get_null();
+        }
+
         auto lhs_generic = lhs_oid.id & ObjectId::GENERIC_TYPE_MASK;
         auto lhs_type = lhs_oid.id & ObjectId::TYPE_MASK;
 
@@ -27,7 +32,7 @@ public:
             || lhs_type == ObjectId::MASK_EDGE_LABEL || lhs_type == ObjectId::MASK_NODE_LABEL
             || lhs_type == ObjectId::MASK_EDGE_KEY || lhs_type == ObjectId::MASK_NODE_KEY)
         {
-            return ObjectId::get_null();
+            return ObjectId(ObjectId::BOOL_FALSE);
         }
 
         bool compatible = false;


### PR DESCRIPTION
## Summary
- Handle null and relation values directly in `BindingExprNotIn`
- Optimize NOT (A IN [...]) to dedicated `BindingExprNotIn` to avoid null inversion

## Testing
- `./scripts/run-tests mql`
- `./scripts/run-tests unit`


------
https://chatgpt.com/codex/tasks/task_e_6894d2dda5688331919d9c58f93f7f67