### PR TITLE
Improve exception handling and documentation

### DIFF
--- a/src/bin/common.h
+++ b/src/bin/common.h
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstdint>
 #include <string>
+#include "misc/fatal_error.h"
 
 namespace MdbBin {
 
@@ -14,6 +15,11 @@ inline std::string to_lower(const std::string& str)
     return res;
 }
 
+/**
+ * Parses a human-readable byte string (e.g. "10MB") into its numeric value.
+ * Conversion errors from std::stoll (std::invalid_argument, std::out_of_range)
+ * are logged and cause the function to return -1.
+ */
 inline int64_t parse_bytes(const std::string& value)
 {
     size_t chars_read;
@@ -39,7 +45,8 @@ inline int64_t parse_bytes(const std::string& value)
             }
             return multiplier * number;
         }
-    } catch (...) {
+    } catch (const std::exception& e) {
+        WARN("Failed to parse bytes: ", e.what());
     }
     return -1;
 }

--- a/src/bin/mdb-import.h
+++ b/src/bin/mdb-import.h
@@ -80,12 +80,13 @@ inline ImportConfig parse_import_config(const std::vector<std::string>& args)
 
     opt.insert({ "--btree-permutations", [](ImportConfig& config, const std::string& value) {
                     try {
-                        auto perms = std::stoi(value);
+                        auto perms = std::stoi(value); // may throw std::invalid_argument or std::out_of_range
                         if (perms == 3 || perms == 4 || perms == 6) {
                             config.btree_permutations = perms;
                             return "";
                         }
-                    } catch (...) {
+                    } catch (const std::exception& e) {
+                        WARN("Invalid btree-permutations value: ", e.what());
                     }
                     return "Invalid value for option \"btree-permutations\". Expected 3, 4 or 6";
                 } });

--- a/src/bin/mdb-server.h
+++ b/src/bin/mdb-server.h
@@ -148,12 +148,13 @@ inline std::map<std::string, std::function<std::string(SystemOptions&, const std
                     } });
         opt.insert({ "port", [](SystemOptions& config, const std::string& value) {
                         try {
-                            auto port = std::stoi(value);
+                            auto port = std::stoi(value); // may throw std::invalid_argument or std::out_of_range
                             if (port >= 1024 && port <= 65535) {
                                 config.port = port;
                                 return "";
                             }
-                        } catch (...) {
+                        } catch (const std::exception& e) {
+                            WARN("Invalid port value: ", e.what());
                         }
                         return "invalid port, expected to be a integer in range 1024 to 65535";
                     } });
@@ -169,23 +170,25 @@ inline std::map<std::string, std::function<std::string(SystemOptions&, const std
                     } });
         opt.insert({ "browser-port", [](SystemOptions& config, const std::string& value) {
                         try {
-                            auto port = std::stoi(value);
+                            auto port = std::stoi(value); // may throw std::invalid_argument or std::out_of_range
                             if (port >= 1024 && port <= 65535) {
                                 config.browser_port = port;
                                 return "";
                             }
-                        } catch (...) {
+                        } catch (const std::exception& e) {
+                            WARN("Invalid browser port value: ", e.what());
                         }
                         return "invalid browser port, expected to be a integer in range 1024 to 65535";
                     } });
         opt.insert({ "threads", [](SystemOptions& config, const std::string& value) {
                         try {
-                            auto threads = std::stoi(value);
+                            auto threads = std::stoi(value); // may throw std::invalid_argument or std::out_of_range
                             if (threads > 0) {
                                 config.workers = threads;
                                 return "";
                             }
-                        } catch (...) {
+                        } catch (const std::exception& e) {
+                            WARN("Invalid worker threads value: ", e.what());
                         }
                         return "invalid worker threads, expected to be a positive integer";
                     } });
@@ -193,12 +196,13 @@ inline std::map<std::string, std::function<std::string(SystemOptions&, const std
 
     opt.insert({ "timeout", [](SystemOptions& config, const std::string& value) {
                     try {
-                        auto seconds = std::stoi(value);
+                        auto seconds = std::stoi(value); // may throw std::invalid_argument or std::out_of_range
                         if (seconds > 0) {
                             config.query_timeout = std::chrono::seconds(seconds);
                             return "";
                         }
-                    } catch (...) {
+                    } catch (const std::exception& e) {
+                        WARN("Invalid timeout value: ", e.what());
                     }
                     return "invalid timeout, expected to be a positive integer";
                 } });

--- a/src/bin/profile-query.cc
+++ b/src/bin/profile-query.cc
@@ -20,11 +20,15 @@ using namespace MdbBin;
 using DurationMS = std::chrono::duration<float, std::milli>;
 using std::chrono::system_clock;
 
+// Logs the stack trace when the program terminates due to an unhandled exception.
+// Any failure while obtaining the stack trace is logged and rethrown.
 void my_terminate_handler()
 {
     try {
         std::cerr << boost::stacktrace::stacktrace();
-    } catch (...) {
+    } catch (const std::exception& e) {
+        WARN("Stacktrace generation failed: ", e.what());
+        throw;
     }
     std::abort();
 }

--- a/src/bin/profile-update.cc
+++ b/src/bin/profile-update.cc
@@ -19,11 +19,15 @@ using namespace MdbBin;
 using DurationMS = std::chrono::duration<float, std::milli>;
 using std::chrono::system_clock;
 
+// Logs the stack trace when the program terminates due to an unhandled exception.
+// Any failure while obtaining the stack trace is logged and rethrown.
 void my_terminate_handler()
 {
     try {
         std::cerr << boost::stacktrace::stacktrace();
-    } catch (...) {
+    } catch (const std::exception& e) {
+        WARN("Stacktrace generation failed: ", e.what());
+        throw;
     }
     std::abort();
 }

--- a/src/graph_models/common/datatypes/tensor/tensor.h
+++ b/src/graph_models/common/datatypes/tensor/tensor.h
@@ -193,7 +193,9 @@ public:
                 }
                 i += bytes_read;
                 EXPECT_COMMA = true;
-            } catch (...) {
+            } catch (const std::exception& e) {
+                // std::stof/std::stod may throw std::invalid_argument or std::out_of_range
+                std::cerr << "Invalid tensor value: " << e.what() << '\n';
                 *error = true;
                 return {};
             }

--- a/src/graph_models/gql/gql_graph_catalog.cc
+++ b/src/graph_models/gql/gql_graph_catalog.cc
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <thread>
 #include <chrono>
+#include "misc/fatal_error.h"
 
 // For JSON serialization we use nlohmann::json if available. If it is not
 // available in the build environment the JSON related code can be replaced
@@ -310,7 +311,8 @@ GqlGraphCatalog::ListResult GqlGraphCatalog::list(const std::optional<std::strin
         const fs::path file_path = fs::path(catalogDirectory_) / (name + ".json");
         try {
             entry.sizeInBytes = fs::file_size(file_path);
-        } catch (...) {
+        } catch (const fs::filesystem_error& e) {
+            WARN("Unable to read file size for ", file_path.string(), ": ", e.what());
             entry.sizeInBytes = 0;
         }
         // Memory usage is not tracked; return empty string
@@ -368,7 +370,8 @@ GqlGraphCatalog::DropResult GqlGraphCatalog::drop(const std::string& graphName,
     const fs::path file_path = fs::path(catalogDirectory_) / (graphName + ".json");
     try {
         entry.sizeInBytes = fs::file_size(file_path);
-    } catch (...) {
+    } catch (const fs::filesystem_error& e) {
+        WARN("Unable to read file size for ", file_path.string(), ": ", e.what());
         entry.sizeInBytes = 0;
     }
     entry.memoryUsage.clear();
@@ -379,8 +382,8 @@ GqlGraphCatalog::DropResult GqlGraphCatalog::drop(const std::string& graphName,
     // Remove from disk
     try {
         fs::remove(file_path);
-    } catch (...) {
-        // ignore errors deleting the file
+    } catch (const fs::filesystem_error& e) {
+        WARN("Failed to remove ", file_path.string(), ": ", e.what());
     }
     return result;
 }

--- a/src/network/server/session/http/http_gql_session.cc
+++ b/src/network/server/session/http/http_gql_session.cc
@@ -235,6 +235,7 @@ void HttpGQLSession::execute_readonly_query_plan(
         logger(Category::Error) << "Unexpected Exception: " << e.what();
     } catch (...) {
         logger(Category::Error) << "Unknown exception";
+        throw;
     }
 }
 

--- a/src/network/server/session/http/http_quad_session.cc
+++ b/src/network/server/session/http/http_quad_session.cc
@@ -235,6 +235,7 @@ void HttpQuadSession::execute_readonly_query_plan(
         logger(Category::Error) << "Unexpected Exception: " << e.what();
     } catch (...) {
         logger(Category::Error) << "Unknown exception";
+        throw;
     }
 }
 

--- a/src/network/server/session/http/http_rdf_session.cc
+++ b/src/network/server/session/http/http_rdf_session.cc
@@ -166,6 +166,7 @@ void HttpRdfSession::execute_readonly_query(
         logger(Category::Error) << "Unexpected Exception: " << e.what();
     } catch (...) {
         logger(Category::Error) << "Unknown exception";
+        throw;
     }
 }
 

--- a/src/network/server/session/streaming/request/streaming_request_handler.cc
+++ b/src/network/server/session/streaming/request/streaming_request_handler.cc
@@ -129,6 +129,7 @@ void StreamingRequestHandler::handle_run(const std::string& query)
         logger(Category::Error) << msg;
         response_writer->write_error(msg);
         response_writer->flush();
+        throw;
     }
 }
 

--- a/src/network/server/session/streaming/streaming_tcp_session.cc
+++ b/src/network/server/session/streaming/streaming_tcp_session.cc
@@ -110,6 +110,7 @@ void StreamingTCPSession::read_request(uint32_t request_size)
                 logger(Category::Error) << "Uncaught exception: " << e.what();
             } catch (...) {
                 logger(Category::Error) << "Unexpected exception!";
+                throw;
             }
 
             self->request_buffer.consume(bytes_transferred);

--- a/src/network/server/session/streaming/streaming_websocket_session.cc
+++ b/src/network/server/session/streaming/streaming_websocket_session.cc
@@ -85,6 +85,7 @@ void StreamingWebSocketSession::run(std::unique_ptr<StreamingWebSocketSession> o
                     logger(Category::Error) << "Uncaught exception: " << e.what();
                 } catch (...) {
                     logger(Category::Error) << "Unexpected exception!";
+                    throw;
                 }
 
                 StreamingWebSocketSession::run(std::move(obj));

--- a/src/query/executor/binding_iter/binding_expr/gql/binding_expr_cast.h
+++ b/src/query/executor/binding_iter/binding_expr/gql/binding_expr_cast.h
@@ -2,6 +2,7 @@
 
 #include "graph_models/gql/conversions.h"
 #include "query/executor/binding_iter/binding_expr/binding_expr.h"
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -58,7 +59,8 @@ public:
                 std::string str = GQL::Conversions::to_lexical_str(operand_oid);
                 try {
                     return GQL::Conversions::pack_int(std::stod(str));
-                } catch (...) {
+                } catch (const std::exception& e) {
+                    std::cerr << "Numeric cast failed: " << e.what() << '\n';
                     return ObjectId::get_null();
                 }
             }
@@ -70,7 +72,8 @@ public:
             if (sourceType == GQL_OID::GenericType::STRING) {
                 try {
                     return ObjectId(DateTime::from_dateTime(Conversions::to_lexical_str(operand_oid)));
-                } catch (...) {
+                } catch (const std::exception& e) {
+                    std::cerr << "Date cast failed: " << e.what() << '\n';
                     return ObjectId::get_null();
                 }
             }

--- a/src/query/executor/binding_iter/binding_expr/sparql/binding_expr_cast.h
+++ b/src/query/executor/binding_iter/binding_expr/sparql/binding_expr_cast.h
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -49,7 +50,8 @@ public:
                 size_t idx;
                 try {
                     flt = std::stof(str, &idx);
-                } catch (...) {
+                } catch (const std::exception& e) {
+                    std::cerr << "Float cast failed: " << e.what() << '\n';
                     return ObjectId::get_null();
                 }
                 if (idx != str.size()) {
@@ -63,7 +65,8 @@ public:
                 size_t idx;
                 try {
                     dbl = std::stod(str, &idx);
-                } catch (...) {
+                } catch (const std::exception& e) {
+                    std::cerr << "Double cast failed: " << e.what() << '\n';
                     return ObjectId::get_null();
                 }
                 if (idx != str.size()) {

--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gds_graph_drop.h"
+#include <iostream>
 
 #include <chrono>
 #include <stdexcept>
@@ -133,8 +134,9 @@ bool GdsGraphDrop::_next()
         // Graph was not found and failIfMissing was false
         assign_nulls();
         return true;
-    } catch (...) {
+    } catch (const std::exception& e) {
         assign_nulls();
+        std::cerr << "Error dropping graph: " << e.what() << '\n';
         throw;
     }
 }

--- a/src/query/executor/binding_iter/procedure/gds_graph_list.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_list.cc
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gds_graph_list.h"
+#include <iostream>
 
 #include "graph_models/common/conversions.h"
 #include "graph_models/gql/conversions.h"
@@ -62,7 +63,8 @@ bool GdsGraphList::_next()
             if (!oid.is_null()) {
                 try {
                     graph_name_filter = GQL::Conversions::unpack_string(oid);
-                } catch (...) {
+                } catch (const std::exception& e) {
+                    std::cerr << "Failed to unpack graph name: " << e.what() << '\n';
                     graph_name_filter = std::nullopt;
                 }
             }

--- a/src/query/executor/binding_iter/procedure/gds_graph_project.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_project.cc
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "gds_graph_project.h"
+#include <iostream>
 
 #include <memory>
 #include <vector>
@@ -95,7 +96,8 @@ GQL::Value object_id_to_value(ObjectId oid)
         // Try integer first, fall back to double
         try {
             return GQL::Value(Common::Conversions::unpack_int(oid));
-        } catch (...) {
+        } catch (const std::exception& e) {
+            std::cerr << "Numeric conversion failed: " << e.what() << '\n';
             return GQL::Value(Common::Conversions::to_double(oid));
         }
     }

--- a/src/storage/index/hnsw/hnsw_index_manager.cc
+++ b/src/storage/index/hnsw/hnsw_index_manager.cc
@@ -38,8 +38,6 @@ void HNSWIndexManager::load_hnsw_index(const std::string& name, const HNSWIndexM
         predicate2names[metadata.predicate].emplace_back(name);
     } catch (const std::exception& e) {
         logger(Category::Error) << "Failed to load HnswIndex \"" + name + "\": " + e.what();
-    } catch (...) {
-        logger(Category::Error) << "Failed to load HnswIndex \"" + name + "\": Unknown error";
     }
 }
 
@@ -159,9 +157,8 @@ std::tuple<uint_fast32_t> HNSWIndexManager::create_hnsw_index(
         has_changes_ = true;
         return { total_inserted_elements };
     } catch (const std::exception& e) {
+        logger(Category::Error) << "Failed to create HNSW index \"" + name + "\": " + e.what();
         throw std::runtime_error("Failed to create HNSW index \"" + name + "\": " + e.what());
-    } catch (...) {
-        throw std::runtime_error("Failed to create HNSW index \"" + name + "\": Unknown error");
     }
 }
 

--- a/src/storage/index/text_search/text_index_manager.cc
+++ b/src/storage/index/text_search/text_index_manager.cc
@@ -45,8 +45,6 @@ void TextIndexManager::load_text_index(
         predicate2names[metadata.predicate].emplace_back(name);
     } catch (const std::exception& e) {
         logger(Category::Error) << "Failed to load TextSearchIndex \"" + name + "\": " + e.what();
-    } catch (...) {
-        logger(Category::Error) << "Failed to load TextSearchIndex \"" + name + "\": Unknown error";
     }
 }
 
@@ -89,8 +87,7 @@ std::tuple<uint_fast32_t, uint_fast32_t> TextIndexManager::create_text_search_in
         has_changes_ = true;
         return { total_inserted_elements, total_inserted_tokens };
     } catch (const std::exception& e) {
+        logger(Category::Error) << "Failed to create TEXT index \"" + name + "\": " + e.what();
         throw std::runtime_error("Failed to create TEXT index \"" + name + "\": " + e.what());
-    } catch (...) {
-        throw std::runtime_error("Failed to create TEXT index \"" + name + "\": Unknown error");
     }
 }


### PR DESCRIPTION
## Summary
- document byte-size parsing errors and log failures
- log and rethrow unknown exceptions across server and catalog modules
- handle filesystem and conversion errors explicitly with warnings

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test -j2` *(fails: Unable to find executable: tests/...)*


------
https://chatgpt.com/codex/tasks/task_e_68964d80ef488321824b213a10b9259f