### PR TITLE
docs: clarify GDS graph procedure arguments

### DIFF
--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.h
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.h
@@ -32,8 +32,21 @@ class GqlGraphCatalog;
 
 /**
  * BindingIter implementation for the GdsGraphDrop procedure.
- * This iterator drops a graph projection from the catalog and yields
- * the dropped graph's metadata as a single result row.
+ * This iterator drops a graph projection from the catalog and yields the
+ * dropped graph's metadata as a single result row.
+ *
+ * Arguments:
+ *   - graphName (STRING): name of the graph to drop. May be supplied as a
+ *     literal or via a variable in the incoming binding.
+ *   - failIfMissing (BOOLEAN, optional, default true): controls behaviour
+ *     when the graph does not exist. If true, an exception is thrown. If
+ *     false, a single row with NULL values is returned.
+ *
+ * Yield columns mirror @ref GQL::GqlGraphCatalog::GraphListEntry and may
+ * include graphName, database, databaseLocation, configuration, nodeCount,
+ * relationshipCount, schema, schemaWithOrientation, degreeDistribution,
+ * density, creationTime, modificationTime, sizeInBytes and memoryUsage.
+ * Both arguments accept variables.
  */
 class GdsGraphDrop : public BindingIter {
 public:

--- a/src/query/executor/binding_iter/procedure/gds_graph_list.h
+++ b/src/query/executor/binding_iter/procedure/gds_graph_list.h
@@ -29,9 +29,17 @@
 
 /**
  * BindingIter implementation for the gds.graph.list procedure.
- * Usage: `CALL gds.graph.list()` with an optional YIELD clause to
- * specify the returned columns. This iterator lists graph projections
- * in the catalog and yields each graph's metadata as a result row.
+ *
+ * Usage: `CALL gds.graph.list([graphName]) YIELD ...` where the optional
+ *  argument may be provided as a literal or as a variable bound in the
+ *  incoming row. When specified, only the matching graph is listed.
+ *
+ * Yield columns correspond to fields of @ref GQL::GqlGraphCatalog::GraphListEntry:
+ * graphName, database, databaseLocation, configuration, nodeCount,
+ * relationshipCount, schema, schemaWithOrientation, degreeDistribution,
+ * density, creationTime, modificationTime, sizeInBytes and memoryUsage.
+ * Columns not requested in the YIELD clause are ignored; requested columns
+ * without a corresponding catalog value are returned as NULL.
  */
 class GdsGraphList : public BindingIter {
 public:

--- a/src/query/executor/binding_iter/procedure/gds_graph_project.h
+++ b/src/query/executor/binding_iter/procedure/gds_graph_project.h
@@ -29,17 +29,28 @@
 
 /**
  * Binding iterator for the GdsGraphProject() procedure.
- * 
+ *
  * This iterator executes a graph projection operation that creates a new
  * logical graph from a subset of nodes and relationships in the database.
- * 
- * Expected signature:
- * CALL GdsGraphProject(
- *   graphName: STRING,
- *   nodeProjection: Value,
- *   relationshipProjection: Value,
- *   configuration: MAP
- * ) YIELD graphName, nodeCount, relationshipCount, projectMillis
+ *
+ * Arguments (all must currently be provided as literal expressions; variable
+ *  references are not supported):
+ *   - graphName (STRING): name of the projected graph.
+ *   - nodeProjection (Value): description of nodes to include in the
+ *     projection.
+ *   - relationshipProjection (Value): description of relationships to
+ *     include in the projection.
+ *   - configuration (MAP): additional projection options.
+ *
+ * Yielded columns, in order:
+ *   - graphName (STRING)
+ *   - nodeProjection (STRING representation of the argument)
+ *   - nodeCount (INTEGER)
+ *   - relationshipProjection (STRING representation of the argument)
+ *   - relationshipCount (INTEGER)
+ *   - projectMillis (INTEGER execution time)
+ *   - query (currently always NULL)
+ *   - configuration (STRING representation of the argument)
  */
 class GdsGraphProject : public BindingIter {
 public:


### PR DESCRIPTION
## Summary
- document required arguments and return columns for GDS graph procedures
- note variable argument support and describe failIfMissing behavior

## Testing
- `cmake -S . -B build` (succeeded)
- `cmake --build build` (interrupted at 16%)
- `ctest --test-dir build` (executables missing)


------
https://chatgpt.com/codex/tasks/task_e_68964d8de2c8832186aa1c961a47f21e