### PR TITLE
Fix GDS drop result handling

### DIFF
--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
@@ -131,8 +131,7 @@ bool GdsGraphDrop::_next()
         }
 
         // Graph was not found and failIfMissing was false
-        assign_nulls();
-        return true;
+        return false;
     } catch (...) {
         assign_nulls();
         throw;


### PR DESCRIPTION
## Summary
- Return `false` instead of emitting nulls when GDS graph drop finds no graph

## Testing
- `./scripts/run-tests unit` *(interrupted: build did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68964d8b2f888321bb901c6d9d28d5f9