### PR TITLE
Fix procedure identifier normalization in GQL parser

### DIFF
--- a/src/query/parser/grammar/gql/query_visitor.cc
+++ b/src/query/parser/grammar/gql/query_visitor.cc
@@ -2052,7 +2052,9 @@ std::any QueryVisitor::visitNamedProcedureCall(GQLParser::NamedProcedureCallCont
     normalized_procedure_name.reserve(procedure_name.size());
     for (char c : procedure_name) {
         if (c != '.') {
-            normalized_procedure_name.push_back(static_cast<char>(std::tolower(c)));
+            normalized_procedure_name.push_back(
+                static_cast<char>(std::tolower(static_cast<unsigned char>(c)))
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Normalize procedure names by stripping dots and lowercasing using unsigned-char conversion.

## Testing
- `cmake --build build` *(incomplete; build interrupted)*
- `ctest --test-dir build` *(fails: Unable to find executable: /workspace/MillenniumDB_Testing/build/tests/compare_datetime)*

------
https://chatgpt.com/codex/tasks/task_e_68964d86e3a88321a0fb81e9081b2ea2