### PR TITLE
Add tests for catalog field assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(TEST_TARGETS
     tensor_operations
     gds_graph_list
     gds_graph_drop
+    gds_catalog_utils
 )
 # Build targets
 foreach(target ${BUILD_TARGETS})
@@ -132,7 +133,11 @@ endforeach(target)
 # Test targets
 enable_testing()
 foreach(target ${TEST_TARGETS})
-    add_executable(${target} ${CMAKE_SOURCE_DIR}/src/tests/${target}.cc)
+    if(target STREQUAL "gds_catalog_utils")
+        add_executable(${target} ${CMAKE_SOURCE_DIR}/tests/gds_catalog_utils.test.cc)
+    else()
+        add_executable(${target} ${CMAKE_SOURCE_DIR}/src/tests/${target}.cc)
+    endif()
     set_target_properties(${target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
     target_link_libraries(${target}
         millenniumdb

--- a/src/query/executor/binding_iter/procedure/gds_catalog_utils.h
+++ b/src/query/executor/binding_iter/procedure/gds_catalog_utils.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <chrono>
+
+#include "graph_models/gql/gql_graph_catalog.h"
+#include "graph_models/common/conversions.h"
+#include "graph_models/gql/conversions.h"
+
+inline ObjectId assign_catalog_field(
+    const GQL::GqlGraphCatalog::GraphListEntry& entry,
+    const std::string& field_name) {
+    using namespace std::chrono;
+    if (field_name == "graphName") {
+        return GQL::Conversions::pack_string_simple(entry.graphName);
+    } else if (field_name == "database") {
+        return GQL::Conversions::pack_string_simple(entry.database);
+    } else if (field_name == "databaseLocation") {
+        return GQL::Conversions::pack_string_simple(entry.databaseLocation);
+    } else if (field_name == "configuration") {
+        return GQL::Conversions::pack_string_simple(entry.configuration);
+    } else if (field_name == "schema") {
+        return GQL::Conversions::pack_string_simple(entry.schema);
+    } else if (field_name == "schemaWithOrientation") {
+        return GQL::Conversions::pack_string_simple(entry.schemaWithOrientation);
+    } else if (field_name == "degreeDistribution") {
+        return GQL::Conversions::pack_string_simple(entry.degreeDistribution);
+    } else if (field_name == "memoryUsage") {
+        return GQL::Conversions::pack_string_simple(entry.memoryUsage);
+    } else if (field_name == "nodeCount") {
+        return Common::Conversions::pack_int(static_cast<int64_t>(entry.nodeCount));
+    } else if (field_name == "relationshipCount") {
+        return Common::Conversions::pack_int(static_cast<int64_t>(entry.relationshipCount));
+    } else if (field_name == "density") {
+        return Common::Conversions::pack_double(entry.density);
+    } else if (field_name == "creationTime") {
+        return Common::Conversions::pack_int(static_cast<int64_t>(
+            duration_cast<milliseconds>(entry.creationTime.time_since_epoch()).count()));
+    } else if (field_name == "modificationTime") {
+        return Common::Conversions::pack_int(static_cast<int64_t>(
+            duration_cast<milliseconds>(entry.modificationTime.time_since_epoch()).count()));
+    } else if (field_name == "sizeInBytes") {
+        return Common::Conversions::pack_int(static_cast<int64_t>(entry.sizeInBytes));
+    }
+    return ObjectId::get_null();
+}
+

--- a/tests/gds_catalog_utils.test.cc
+++ b/tests/gds_catalog_utils.test.cc
@@ -1,0 +1,59 @@
+#include "query/executor/binding_iter/procedure/gds_catalog_utils.h"
+#include "graph_models/common/conversions.h"
+#include "graph_models/gql/conversions.h"
+#include <chrono>
+#include <iostream>
+
+using namespace std::chrono;
+
+bool test_assign_catalog_field() {
+    GQL::GqlGraphCatalog::GraphListEntry entry;
+    entry.graphName = "g";
+    entry.database = "db";
+    entry.databaseLocation = "/tmp/db";
+    entry.configuration = "{}";
+    entry.nodeCount = 1;
+    entry.relationshipCount = 2;
+    entry.schema = "s";
+    entry.schemaWithOrientation = "so";
+    entry.degreeDistribution = "dd";
+    entry.density = 0.5;
+    entry.creationTime = system_clock::time_point{milliseconds{1000}};
+    entry.modificationTime = system_clock::time_point{milliseconds{2000}};
+    entry.sizeInBytes = 42;
+    entry.memoryUsage = "1k";
+
+    bool error = false;
+    auto check = [&](const std::string& field, ObjectId expected) {
+        auto got = assign_catalog_field(entry, field);
+        if (got != expected) {
+            std::cerr << "mismatch for " << field << "\n";
+            error = true;
+        }
+    };
+
+    check("graphName", GQL::Conversions::pack_string_simple(entry.graphName));
+    check("database", GQL::Conversions::pack_string_simple(entry.database));
+    check("databaseLocation", GQL::Conversions::pack_string_simple(entry.databaseLocation));
+    check("configuration", GQL::Conversions::pack_string_simple(entry.configuration));
+    check("nodeCount", Common::Conversions::pack_int(static_cast<int64_t>(entry.nodeCount)));
+    check("relationshipCount", Common::Conversions::pack_int(static_cast<int64_t>(entry.relationshipCount)));
+    check("schema", GQL::Conversions::pack_string_simple(entry.schema));
+    check("schemaWithOrientation", GQL::Conversions::pack_string_simple(entry.schemaWithOrientation));
+    check("degreeDistribution", GQL::Conversions::pack_string_simple(entry.degreeDistribution));
+    check("density", Common::Conversions::pack_double(entry.density));
+    check("creationTime", Common::Conversions::pack_int(static_cast<int64_t>(
+        duration_cast<milliseconds>(entry.creationTime.time_since_epoch()).count())));
+    check("modificationTime", Common::Conversions::pack_int(static_cast<int64_t>(
+        duration_cast<milliseconds>(entry.modificationTime.time_since_epoch()).count())));
+    check("sizeInBytes", Common::Conversions::pack_int(static_cast<int64_t>(entry.sizeInBytes)));
+    check("memoryUsage", GQL::Conversions::pack_string_simple(entry.memoryUsage));
+    check("unknown", ObjectId::get_null());
+
+    return error;
+}
+
+int main() {
+    return test_assign_catalog_field() ? 1 : 0;
+}
+


### PR DESCRIPTION
## Summary
- add helper to translate graph catalog fields into ObjectId values
- test field assignment for all supported catalog properties

## Testing
- `cmake -S . -B build`
- `cmake --build build --target gds_catalog_utils` *(failed: build terminated)*

------
https://chatgpt.com/codex/tasks/task_e_689a410857cc8321ba19560f96c01848