### PR TITLE
Add missing includes for GDS graph tests

### DIFF
--- a/src/tests/gds_graph_drop.cc
+++ b/src/tests/gds_graph_drop.cc
@@ -1,3 +1,4 @@
+#include "graph_models/gql/gql_value.h"
 #include "query/executor/binding_iter/procedure/gds_graph_drop.h"
 #include "graph_models/common/conversions.h"
 #include "graph_models/gql/conversions.h"

--- a/src/tests/gds_graph_list.cc
+++ b/src/tests/gds_graph_list.cc
@@ -1,3 +1,5 @@
+#include "graph_models/gql/gql_value.h"
+#include "query/parser/expr/gql/expr_term.h"
 #include "query/executor/binding_iter/procedure/gds_graph_list.h"
 #include "graph_models/common/conversions.h"
 #include "graph_models/gql/conversions.h"


### PR DESCRIPTION
## Summary
- include gql_value in graph listing and dropping tests
- include ExprTerm in gds_graph_list test

## Testing
- `scripts/run-tests unit gds_graph_list gds_graph_drop` *(fails: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689abb0d8f908321b426eeb5a16c3fae