### PR TITLE
Fix density packing in GDS catalog utilities

### DIFF
--- a/src/query/executor/binding_iter/procedure/gds_catalog_utils.h
+++ b/src/query/executor/binding_iter/procedure/gds_catalog_utils.h
@@ -32,7 +32,7 @@ inline ObjectId assign_catalog_field(
     } else if (field_name == "relationshipCount") {
         return Common::Conversions::pack_int(static_cast<int64_t>(entry.relationshipCount));
     } else if (field_name == "density") {
-        return Common::Conversions::pack_double(entry.density);
+        return Common::Conversions::pack_float(static_cast<float>(entry.density));
     } else if (field_name == "creationTime") {
         return Common::Conversions::pack_int(static_cast<int64_t>(
             duration_cast<milliseconds>(entry.creationTime.time_since_epoch()).count()));

--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
@@ -99,7 +99,7 @@ bool GdsGraphDrop::_next()
                 { "schema", GQL::Conversions::pack_string_simple(entry.schema) },
                 { "schemaWithOrientation", GQL::Conversions::pack_string_simple(entry.schemaWithOrientation) },
                 { "degreeDistribution", GQL::Conversions::pack_string_simple(entry.degreeDistribution) },
-                { "density", Common::Conversions::pack_double(entry.density) },
+                { "density", Common::Conversions::pack_float(static_cast<float>(entry.density)) },
                 { "creationTime", Common::Conversions::pack_int(static_cast<int64_t>(
                                      std::chrono::duration_cast<std::chrono::milliseconds>(
                                          entry.creationTime.time_since_epoch()).count())) },

--- a/src/query/executor/binding_iter/procedure/gds_graph_list.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_list.cc
@@ -93,7 +93,7 @@ bool GdsGraphList::_next()
         { "memoryUsage", GQL::Conversions::pack_string_simple(entry.memoryUsage) },
         { "nodeCount", Common::Conversions::pack_int(static_cast<int64_t>(entry.nodeCount)) },
         { "relationshipCount", Common::Conversions::pack_int(static_cast<int64_t>(entry.relationshipCount)) },
-        { "density", Common::Conversions::pack_double(entry.density) },
+        { "density", Common::Conversions::pack_float(static_cast<float>(entry.density)) },
         { "creationTime", Common::Conversions::pack_int(static_cast<int64_t>(
                               std::chrono::duration_cast<std::chrono::milliseconds>(
                                   entry.creationTime.time_since_epoch()).count())) },

--- a/tests/gds_catalog_utils.test.cc
+++ b/tests/gds_catalog_utils.test.cc
@@ -41,7 +41,7 @@ bool test_assign_catalog_field() {
     check("schema", GQL::Conversions::pack_string_simple(entry.schema));
     check("schemaWithOrientation", GQL::Conversions::pack_string_simple(entry.schemaWithOrientation));
     check("degreeDistribution", GQL::Conversions::pack_string_simple(entry.degreeDistribution));
-    check("density", Common::Conversions::pack_double(entry.density));
+    check("density", Common::Conversions::pack_float(static_cast<float>(entry.density)));
     check("creationTime", Common::Conversions::pack_int(static_cast<int64_t>(
         duration_cast<milliseconds>(entry.creationTime.time_since_epoch()).count())));
     check("modificationTime", Common::Conversions::pack_int(static_cast<int64_t>(


### PR DESCRIPTION
## Summary
- Pack graph density using `pack_float` to avoid string manager dependency
- Update GDS graph list/drop procedures and unit test accordingly

## Testing
- `scripts/run-tests unit gds_catalog_utils`


------
https://chatgpt.com/codex/tasks/task_e_689ad119e34083219f55b6da4dfb7d0e