### PR TITLE
Clarify GDS procedure documentation and drop behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ The main objective of this project is to create a fully functional and easy-to-e
 
     The engine also supports a subset of Neo4j's Graph Data Science procedures
     via the `CALL` clause, for example `CALL gds.graph.list()` to inspect the
-    catalog of projected graphs.
+    catalog of projected graphs. Procedures like `gds.graph.project` and
+    `gds.graph.drop` accept variables for their arguments; the latter yields no
+    row when asked to drop a non-existent graph with `failIfMissing` set to
+    `false`.
 
 This project is still in active development and is not production ready yet, some functionality is missing and there may be bugs.
 

--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.cc
@@ -139,8 +139,7 @@ bool GdsGraphDrop::_next()
         }
 
         // Graph was not found and failIfMissing was false
-        assign_nulls();
-        return true;
+        return false;
     } catch (const std::exception& e) {
         assign_nulls();
         std::cerr << "Error dropping graph: " << e.what() << '\n';

--- a/src/query/executor/binding_iter/procedure/gds_graph_drop.h
+++ b/src/query/executor/binding_iter/procedure/gds_graph_drop.h
@@ -32,15 +32,15 @@ class GqlGraphCatalog;
 
 /**
  * BindingIter implementation for the GdsGraphDrop procedure.
- * This iterator drops a graph projection from the catalog and yields the
- * dropped graph's metadata as a single result row.
+ * This iterator drops a graph projection from the catalog. When the graph
+ * exists, its metadata is yielded as a single result row.
  *
  * Arguments:
  *   - graphName (STRING): name of the graph to drop. May be supplied as a
  *     literal or via a variable in the incoming binding.
  *   - failIfMissing (BOOLEAN, optional, default true): controls behaviour
  *     when the graph does not exist. If true, an exception is thrown. If
- *     false, a single row with NULL values is returned.
+ *     false, no row is returned.
  *
  * Yield columns mirror @ref GQL::GqlGraphCatalog::GraphListEntry and may
  * include graphName, database, databaseLocation, configuration, nodeCount,

--- a/src/query/executor/binding_iter/procedure/gds_graph_project.h
+++ b/src/query/executor/binding_iter/procedure/gds_graph_project.h
@@ -33,8 +33,7 @@
  * This iterator executes a graph projection operation that creates a new
  * logical graph from a subset of nodes and relationships in the database.
  *
- * Arguments (all must currently be provided as literal expressions; variable
- *  references are not supported):
+ * Arguments (literals or variables are allowed):
  *   - graphName (STRING): name of the projected graph.
  *   - nodeProjection (Value): description of nodes to include in the
  *     projection.

--- a/tests/gql/test_suites/procedures/queries/call_gds_graph_drop_fail_false.csv
+++ b/tests/gql/test_suites/procedures/queries/call_gds_graph_drop_fail_false.csv
@@ -1,2 +1,1 @@
 graphName
-NULL


### PR DESCRIPTION
## Summary
- Document variable support for `gds.graph.project`
- Describe new behavior of `gds.graph.drop` when the graph is missing
- Note GDS procedure details in README and adjust test expectations

## Testing
- `pytest tests/gql/test_suites/procedures` (no tests run)
- `make test` (fails: No rule to make target 'test')
- `ctest` (fails: No test configuration file found)


------
https://chatgpt.com/codex/tasks/task_e_689b695a8f74832182cbfa6a742f44f0