### PR TITLE
Handle non-ASCII procedure names safely

### DIFF
--- a/src/query/parser/grammar/gql/query_visitor.cc
+++ b/src/query/parser/grammar/gql/query_visitor.cc
@@ -2052,7 +2052,9 @@ std::any QueryVisitor::visitNamedProcedureCall(GQLParser::NamedProcedureCallCont
     normalized_procedure_name.reserve(procedure_name.size());
     for (char c : procedure_name) {
         if (c != '.') {
-            normalized_procedure_name.push_back(static_cast<char>(std::tolower(c)));
+            normalized_procedure_name.push_back(
+                static_cast<char>(std::tolower(static_cast<unsigned char>(c)))
+            );
         }
     }
 

--- a/tests/gql/test_suites/procedures/queries/call_non_ascii_procedure_name_upper.bad.mql
+++ b/tests/gql/test_suites/procedures/queries/call_non_ascii_procedure_name_upper.bad.mql
@@ -1,0 +1,1 @@
+CALL GDS.GRÁPH.LIST()


### PR DESCRIPTION
## Summary
- Avoid UB in procedure name normalization by converting each character with `std::tolower(static_cast<unsigned char>(c))`
- Add regression test with uppercase accented characters to ensure non-ASCII procedure calls are handled safely

## Testing
- `build/Release/bin/mdb help`
- `python3 tests/gql/scripts/test.py --executable build/Release/bin/mdb` *(fails: Remote end closed connection without response)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c446f38832193e2e1dd1929660c